### PR TITLE
Previous Consul entries created by Consular but no longer in Marathon are not cleared

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .coverage
 _trial_temp/
 /docs/_build
+htmlcov/

--- a/consular/cli.py
+++ b/consular/cli.py
@@ -16,11 +16,10 @@ from urllib import urlencode
 @click.option('--marathon', default='http://localhost:8080',
               help='The Marathon HTTP API')
 @click.option('--registration-id',
-              help=('Auto register for Marathon event callbacks with the '
-                    'registration-id. Also used to identify which services in '
-                    'Consul should be maintained by consular. Must be unique '
+              help=('Name used to register for event callbacks in Marathon as '
+                    'well as to register services in Consul. Must be unique '
                     'for each consular process.'),
-              type=str, required=True)
+              type=str, default='consular')
 @click.option('--sync-interval',
               help=('Automatically sync the apps in Marathon with what\'s '
                     'in Consul every _n_ seconds. Defaults to 0 (disabled).'),

--- a/consular/cli.py
+++ b/consular/cli.py
@@ -60,7 +60,7 @@ def main(scheme, host, port,
 
     log.startLogging(logfile)
 
-    consular = Consular(consul, marathon, fallback)
+    consular = Consular(consul, marathon, fallback, registration_id)
     consular.debug = debug
     consular.timeout = timeout
     consular.fallback_timeout = fallback_timeout

--- a/consular/cli.py
+++ b/consular/cli.py
@@ -17,8 +17,10 @@ from urllib import urlencode
               help='The Marathon HTTP API')
 @click.option('--registration-id',
               help=('Auto register for Marathon event callbacks with the '
-                    'registration-id. Must be unique for each consular '
-                    'process.'), type=str)
+                    'registration-id. Also used to identify which services in '
+                    'Consul should be maintained by consular. Must be unique '
+                    'for each consular process.'),
+              type=str)
 @click.option('--sync-interval',
               help=('Automatically sync the apps in Marathon with what\'s '
                     'in Consul every _n_ seconds. Defaults to 0 (disabled).'),
@@ -64,6 +66,7 @@ def main(scheme, host, port,
     consular.timeout = timeout
     consular.fallback_timeout = fallback_timeout
     if registration_id:
+        consular.registration_id = registration_id
         events_url = "%s://%s:%s/events?%s" % (
             scheme, host, port,
             urlencode({

--- a/consular/cli.py
+++ b/consular/cli.py
@@ -20,7 +20,7 @@ from urllib import urlencode
                     'registration-id. Also used to identify which services in '
                     'Consul should be maintained by consular. Must be unique '
                     'for each consular process.'),
-              type=str)
+              type=str, required=True)
 @click.option('--sync-interval',
               help=('Automatically sync the apps in Marathon with what\'s '
                     'in Consul every _n_ seconds. Defaults to 0 (disabled).'),
@@ -65,14 +65,12 @@ def main(scheme, host, port,
     consular.debug = debug
     consular.timeout = timeout
     consular.fallback_timeout = fallback_timeout
-    if registration_id:
-        consular.registration_id = registration_id
-        events_url = "%s://%s:%s/events?%s" % (
-            scheme, host, port,
-            urlencode({
-                'registration': registration_id,
-            }))
-        consular.register_marathon_event_callback(events_url)
+    events_url = "%s://%s:%s/events?%s" % (
+        scheme, host, port,
+        urlencode({
+            'registration': registration_id,
+        }))
+    consular.register_marathon_event_callback(events_url)
 
     if sync_interval > 0:
         lc = LoopingCall(consular.sync_apps, purge)

--- a/consular/tests/test_main.py
+++ b/consular/tests/test_main.py
@@ -38,7 +38,8 @@ class ConsularTest(TestCase):
         self.consular = Consular(
             'http://localhost:8500',
             'http://localhost:8080',
-            False
+            False,
+            'test'
         )
         self.consular.debug = True
 
@@ -169,6 +170,7 @@ class ConsularTest(TestCase):
             'ID': 'my-app_0-1396592784349',
             'Address': 'slave-1234.acme.org',
             'Port': 31372,
+            'Tags': ['consular-reg-id:test'],
         }))
         request['deferred'].callback(
             FakeResponse(200, [], json.dumps({})))
@@ -279,6 +281,7 @@ class ConsularTest(TestCase):
             'ID': 'my-task-id',
             'Address': '0.0.0.0',
             'Port': 1234,
+            'Tags': ['consular-reg-id:test'],
         }))
         self.assertEqual(consul_request['method'], 'PUT')
         consul_request['deferred'].callback(
@@ -354,14 +357,16 @@ class ConsularTest(TestCase):
                     "Service": "testingapp",
                     "Tags": None,
                     "Address": "machine-1",
-                    "Port": 8102
+                    "Port": 8102,
+                    'Tags': ['consular-reg-id:test'],
                 },
                 "testingapp.someid2": {
                     "ID": "testingapp.someid2",
                     "Service": "testingapp",
                     "Tags": None,
                     "Address": "machine-2",
-                    "Port": 8103
+                    "Port": 8103,
+                    'Tags': ['consular-reg-id:test'],
                 }
             }))
         )
@@ -404,7 +409,6 @@ class ConsularTest(TestCase):
         Services previously registered with Consul by Consular but that no
         longer exist in Marathon should be purged if a registration ID is set.
         """
-        self.consular.registration_id = "test"
         d = self.consular.purge_dead_services()
         consul_request = yield self.requests.get()
         self.assertEqual(
@@ -495,4 +499,5 @@ class ConsularTest(TestCase):
             'ID': 'service_id',
             'Address': 'foo',
             'Port': 1234,
+            'Tags': ['consular-reg-id:test'],
         }))

--- a/consular/tests/test_main.py
+++ b/consular/tests/test_main.py
@@ -399,6 +399,83 @@ class ConsularTest(TestCase):
         yield d
 
     @inlineCallbacks
+    def test_purge_old_services(self):
+        """
+        Services previously registered with Consul by Consular but that no
+        longer exist in Marathon should be purged if a registration ID is set.
+        """
+        self.consular.registration_id = "test"
+        d = self.consular.purge_dead_services()
+        consul_request = yield self.requests.get()
+        self.assertEqual(
+            consul_request['url'],
+            'http://localhost:8500/v1/catalog/nodes')
+        consul_request['deferred'].callback(
+            FakeResponse(200, [], json.dumps([{
+                'Node': 'consul-node',
+                'Address': '1.2.3.4',
+            }]))
+        )
+        agent_request = yield self.requests.get()
+        # Expecting a request to list of all services in Consul, returning 3
+        # services - one tagged with our registration ID, one tagged with a
+        # different registration ID, and one with no tags.
+        self.assertEqual(
+            agent_request['url'],
+            'http://1.2.3.4:8500/v1/agent/services')
+        self.assertEqual(agent_request['method'], 'GET')
+        agent_request['deferred'].callback(
+            FakeResponse(200, [], json.dumps({
+                "testingapp.someid1": {
+                    "ID": "testingapp.someid1",
+                    "Service": "testingapp",
+                    "Tags": [
+                        "consular-reg-id:test"
+                    ],
+                    "Address": "machine-1",
+                    "Port": 8102
+                },
+                "testingapp.someid2": {
+                    "ID": "testingapp.someid2",
+                    "Service": "testingapp",
+                    "Tags": [
+                        "consular-reg-id:blah"
+                    ],
+                    "Address": "machine-2",
+                    "Port": 8103
+                },
+                "testingapp.someid3": {
+                    "ID": "testingapp.someid2",
+                    "Service": "testingapp",
+                    "Tags": None,
+                    "Address": "machine-2",
+                    "Port": 8104
+                }
+            }))
+        )
+
+        # Expecting a request for the tasks for a given app, returning no tasks
+        testingapp_request = yield self.requests.get()
+        self.assertEqual(testingapp_request['url'],
+                         'http://localhost:8080/v2/apps/testingapp/tasks')
+        self.assertEqual(testingapp_request['method'], 'GET')
+        testingapp_request['deferred'].callback(
+            FakeResponse(200, [], json.dumps({}))
+        )
+
+        # Expecting a service deregistering in Consul as a result. Only the
+        # task with the correct tag is returned.
+        deregister_request = yield self.requests.get()
+        self.assertEqual(
+            deregister_request['url'],
+            ('http://1.2.3.4:8500/v1/agent/service/deregister/'
+             'testingapp.someid1'))
+        self.assertEqual(deregister_request['method'], 'PUT')
+        deregister_request['deferred'].callback(
+            FakeResponse(200, [], json.dumps({})))
+        yield d
+
+    @inlineCallbacks
     def test_fallback_to_main_consul(self):
         self.consular.enable_fallback = True
         self.consular.register_service(


### PR DESCRIPTION
Ideally, whenever Marathon runs, so does Consular, in which case this shouldn't be a problem. But if Marathon and Consular run at one point and a whole bunch of service entries are created for Marathon tasks in Consul... and then at some later point Consular is switched off, and a bunch of tasks are removed from Marathon... then when Consular is started up again, it will interpret the old tasks in Consul as non-Marathon entries and will not remove them.

This requires that each old task is manually removed from Consul.
