### PR TITLE
More helpful connection error messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
   directories:
     - $HOME/.cache/pip
 install:
+  - pip install "cryptography<=1.0"
   - pip install twine
   - pip install coveralls
   - pip install --upgrade pip

--- a/consular/main.py
+++ b/consular/main.py
@@ -104,6 +104,10 @@ class Consular(object):
             method, path, data, response.code))
         return response
 
+    def log_http_error(self, failure, url):
+        log.msg('Error performing request to %s' % (url,))
+        failure.raiseException()
+
     def marathon_request(self, method, path, data=None):
         return self._request(
             method, '%s%s' % (self.marathon_endpoint, path), data)
@@ -124,6 +128,7 @@ class Consular(object):
             timeout=timeout or self.timeout)
         if self.debug:
             d.addCallback(self.log_http_response, method, url, data)
+            d.addErrback(self.log_http_error, url)
         return d
 
     @app.route('/')

--- a/consular/main.py
+++ b/consular/main.py
@@ -105,8 +105,8 @@ class Consular(object):
         return response
 
     def log_http_error(self, failure, url):
-        log.msg('Error performing request to %s' % (url,))
-        failure.raiseException()
+        log.err(failure, 'Error performing request to %s' % (url,))
+        return failure
 
     def marathon_request(self, method, path, data=None):
         return self._request(
@@ -126,9 +126,11 @@ class Consular(object):
             data=(json.dumps(data) if data is not None else None),
             pool=self.pool,
             timeout=timeout or self.timeout)
+
         if self.debug:
             d.addCallback(self.log_http_response, method, url, data)
-            d.addErrback(self.log_http_error, url)
+
+        d.addErrback(self.log_http_error, url)
         return d
 
     @app.route('/')

--- a/consular/tests/test_main.py
+++ b/consular/tests/test_main.py
@@ -30,6 +30,10 @@ class FakeResponse(object):
         return d
 
 
+class DummyConsularException(Exception):
+    pass
+
+
 class ConsularTest(TestCase):
 
     timeout = 1
@@ -407,7 +411,10 @@ class ConsularTest(TestCase):
         self.assertEqual(
             request['url'],
             'http://foo:8500/v1/agent/service/register')
-        request['deferred'].errback(Exception('Something terrible'))
+        request['deferred'].errback(
+            DummyConsularException('Something terrible'))
+        [exc] = self.flushLoggedErrors(DummyConsularException)
+        self.assertEqual(str(exc.value), 'Something terrible')
 
         fallback_request = yield self.requests.get()
         self.assertEqual(


### PR DESCRIPTION
If Consular fails to connect to something (either Marathon or Consul) the error message is not very useful. For example:

```
2015-08-19 11:37:12+0200 [-] Unhandled error in Deferred:
2015-08-19 11:37:12+0200 [-] Unhandled Error
    Traceback (most recent call last):
    Failure: twisted.internet.error.ConnectionRefusedError: Connection was refused by other side: 111: Connection refused.
```

This gives no indication of where in the code the request failed and what Consular was trying to connect to when it failed. It would be useful to at least know whether Consular failed trying to connect to Marathon or to Consul.
