### PR TITLE
Use ls | explode to reduce consul-template logspam

### DIFF
--- a/templates/nginx.ctmpl
+++ b/templates/nginx.ctmpl
@@ -7,7 +7,7 @@
 #       Nginx. If the key does not exist the service isn't added to the
 #       list of services in the Nginx config.
 
-{{range services}}{{if key (print "consular/" .Name "/domain") }}
+{{range services}}{{$labels = ls (print "consular/" .Name) | explode }}{{if $labels.domain}}
 
 upstream {{.Name}} {
   {{range service .Name }}server {{.Address}}:{{.Port}};
@@ -16,7 +16,7 @@ upstream {{.Name}} {
 
 server {
   listen 80;
-  server_name {{key (print "consular/" .Name "/domain") | parseJSON }};
+  server_name {{$labels.domain | parseJSON }};
 
   location / {
     proxy_pass http://{{.Name}};


### PR DESCRIPTION
Removes these annoying messages from the logs:
`consul-template[19893]: ("key(consular/marathon/domain)") Consul returned no data (does the path exist?)`

This also makes it easier to access new Marathon labels.

See hashicorp/consul-template#368
