### PR TITLE
Purging not working for Marathon apps in non-root groups

### DIFF
--- a/consular/main.py
+++ b/consular/main.py
@@ -439,6 +439,13 @@ class Consular(object):
                 app_id = self.get_app_id_from_tags(tags)
                 if app_id:
                     services.setdefault(app_id, set()).add(service_id)
+                else:
+                    log.msg('Service "%s" does not have an app ID in its '
+                            'tags, it cannot be purged.'
+                            % (service['Service'],))
+            elif self.debug:
+                log.msg('Service "%s" is not tagged with our registration ID, '
+                        'not touching it.' % (service['Service'],))
 
         for app_id, task_ids in services.items():
             yield self.purge_service_if_dead(agent_endpoint, app_id, task_ids)

--- a/consular/main.py
+++ b/consular/main.py
@@ -17,9 +17,9 @@ from klein import Klein
 def get_app_name(app_id):
     """
     Get the app name from the marathon app ID. Separators in the ID ('/') are
-    replaced with '-'s while leading and trailing separators are removed.
+    replaced with '-'s while the leading separator is removed.
     """
-    return app_id.strip('/').replace('/', '-')
+    return app_id.lstrip('/').replace('/', '-')
 
 
 def get_agent_endpoint(host):
@@ -416,12 +416,9 @@ class Consular(object):
             # Check the service for a tag that matches our registration ID
             tags = service['Tags']
             if self._is_registration_in_tags(tags):
-                # Get the app ID from the tags or default to the service name
                 app_id = self._get_app_id_from_tags(tags)
-                if not app_id:
-                    app_id = service['Service']
-
-                services.setdefault(app_id, set()).add(service_id)
+                if app_id:
+                    services.setdefault(app_id, set()).add(service_id)
 
         for app_id, task_ids in services.items():
             yield self.purge_service_if_dead(agent_endpoint, app_id, task_ids)
@@ -456,7 +453,7 @@ class Consular(object):
     @inlineCallbacks
     def purge_service_if_dead(self, agent_endpoint, app_id, consul_task_ids):
         response = yield self.marathon_request(
-            'GET', '/v2/apps/%s/tasks' % (app_id,))
+            'GET', '/v2/apps%s/tasks' % (app_id,))
         data = yield response.json()
         tasks_to_be_purged = set(consul_task_ids)
         if 'tasks' in data:

--- a/consular/tests/test_main.py
+++ b/consular/tests/test_main.py
@@ -86,13 +86,16 @@ class ConsularTest(TestCase):
         pass
 
     def test_reg_id_tag(self):
+        """ Consular's registration ID tag is properly formed. """
         self.assertEqual(self.consular.reg_id_tag(), 'consular-reg-id=test')
 
     def test_app_id_tag(self):
+        """ Consular's application ID tag is properly formed. """
         self.assertEqual(self.consular.app_id_tag('test'),
                          'consular-app-id=test')
 
     def test_get_app_id_from_tags(self):
+        """ The app ID is successfully parsed from the Consul tags. """
         tags = [
             'randomstuff',
             'consular-reg-id=test',
@@ -101,6 +104,9 @@ class ConsularTest(TestCase):
         self.assertEqual(self.consular.get_app_id_from_tags(tags), '/my-app')
 
     def test_get_app_id_from_tags_not_found(self):
+        """
+        None is returned when the app ID cannot be found in the Consul tags.
+        """
         tags = [
             'randomstuff',
             'consular-reg-id=test',
@@ -108,6 +114,10 @@ class ConsularTest(TestCase):
         self.assertEqual(self.consular.get_app_id_from_tags(tags), None)
 
     def test_get_app_id_from_tags_multiple(self):
+        """
+        An exception is raised when multiple app IDs are found in the Consul
+        tags.
+        """
         tags = [
             'randomstuff',
             'consular-reg-id=test',

--- a/consular/tests/test_main.py
+++ b/consular/tests/test_main.py
@@ -390,21 +390,27 @@ class ConsularTest(TestCase):
         self.assertEqual(agent_request['method'], 'GET')
         agent_request['deferred'].callback(
             FakeResponse(200, [], json.dumps({
-                "testingapp.someid1": {
-                    "ID": "testingapp.someid1",
+                "testinggroup-someid1": {
+                    "ID": "taskid1",
                     "Service": "testingapp",
                     "Tags": None,
                     "Address": "machine-1",
                     "Port": 8102,
-                    'Tags': ['consular-reg-id:test'],
+                    "Tags": [
+                        "consular-reg-id:test",
+                        "consular-app-id:/testinggroup/someid1",
+                    ],
                 },
-                "testingapp.someid2": {
-                    "ID": "testingapp.someid2",
+                "testinggroup-someid1": {
+                    "ID": "taskid2",
                     "Service": "testingapp",
                     "Tags": None,
                     "Address": "machine-2",
                     "Port": 8103,
-                    'Tags': ['consular-reg-id:test'],
+                    "Tags": [
+                        "consular-reg-id:test",
+                        "consular-app-id:/testinggroup/someid1",
+                    ],
                 }
             }))
         )
@@ -413,13 +419,14 @@ class ConsularTest(TestCase):
         # 1 less than Consul thinks exists.
         testingapp_request = yield self.requests.get()
         self.assertEqual(testingapp_request['url'],
-                         'http://localhost:8080/v2/apps/testingapp/tasks')
+                         'http://localhost:8080/v2/apps/testinggroup/someid1/'
+                         'tasks')
         self.assertEqual(testingapp_request['method'], 'GET')
         testingapp_request['deferred'].callback(
             FakeResponse(200, [], json.dumps({
                 "tasks": [{
-                    "appId": "/testingapp",
-                    "id": "testingapp.someid2",
+                    "appId": "/testinggroup/someid1",
+                    "id": "taskid2",
                     "host": "machine-2",
                     "ports": [8103],
                     "startedAt": "2015-07-14T14:54:31.934Z",
@@ -435,7 +442,7 @@ class ConsularTest(TestCase):
         self.assertEqual(
             deregister_request['url'],
             ('http://1.2.3.4:8500/v1/agent/service/deregister/'
-             'testingapp.someid1'))
+             'testinggroup-someid1'))
         self.assertEqual(deregister_request['method'], 'PUT')
         deregister_request['deferred'].callback(
             FakeResponse(200, [], json.dumps({})))
@@ -472,7 +479,8 @@ class ConsularTest(TestCase):
                     "ID": "testingapp.someid1",
                     "Service": "testingapp",
                     "Tags": [
-                        "consular-reg-id:test"
+                        "consular-reg-id:test",
+                        "consular-app-id:/testingapp",
                     ],
                     "Address": "machine-1",
                     "Port": 8102
@@ -481,7 +489,8 @@ class ConsularTest(TestCase):
                     "ID": "testingapp.someid2",
                     "Service": "testingapp",
                     "Tags": [
-                        "consular-reg-id:blah"
+                        "consular-reg-id:blah",
+                        "consular-app-id:/testingapp",
                     ],
                     "Address": "machine-2",
                     "Port": 8103

--- a/consular/tests/test_main.py
+++ b/consular/tests/test_main.py
@@ -299,6 +299,34 @@ class ConsularTest(TestCase):
         yield d
 
     @inlineCallbacks
+    def test_sync_app_task_grouped(self):
+        """
+        When syncing an app in a group with a task, Consul is updated with a
+        service entry for the task.
+        """
+        app = {'id': '/my-group/my-app'}
+        task = {'id': 'my-task-id', 'host': '0.0.0.0', 'ports': [1234]}
+        d = self.consular.sync_app_task(app, task)
+        consul_request = yield self.requests.get()
+        self.assertEqual(
+            consul_request['url'],
+            'http://0.0.0.0:8500/v1/agent/service/register')
+        self.assertEqual(consul_request['data'], json.dumps({
+            'Name': 'my-group-my-app',
+            'ID': 'my-task-id',
+            'Address': '0.0.0.0',
+            'Port': 1234,
+            'Tags': [
+                'consular-reg-id:test',
+                'consular-app-id:/my-group/my-app',
+            ],
+        }))
+        self.assertEqual(consul_request['method'], 'PUT')
+        consul_request['deferred'].callback(
+            FakeResponse(200, [], json.dumps({})))
+        yield d
+
+    @inlineCallbacks
     def test_sync_app_labels(self):
         app = {
             'id': '/my-app',

--- a/consular/tests/test_main.py
+++ b/consular/tests/test_main.py
@@ -85,6 +85,42 @@ class ConsularTest(TestCase):
     def tearDown(self):
         pass
 
+    def test_reg_id_tag(self):
+        self.assertEqual(self.consular.reg_id_tag(), 'consular-reg-id=test')
+
+    def test_app_id_tag(self):
+        self.assertEqual(self.consular.app_id_tag('test'),
+                         'consular-app-id=test')
+
+    def test_get_app_id_from_tags(self):
+        tags = [
+            'randomstuff',
+            'consular-reg-id=test',
+            'consular-app-id=/my-app',
+        ]
+        self.assertEqual(self.consular.get_app_id_from_tags(tags), '/my-app')
+
+    def test_get_app_id_from_tags_not_found(self):
+        tags = [
+            'randomstuff',
+            'consular-reg-id=test',
+        ]
+        self.assertEqual(self.consular.get_app_id_from_tags(tags), None)
+
+    def test_get_app_id_from_tags_multiple(self):
+        tags = [
+            'randomstuff',
+            'consular-reg-id=test',
+            'consular-app-id=/my-app',
+            'consular-app-id=/my-app2',
+        ]
+        exception = self.assertRaises(RuntimeError,
+                                      self.consular.get_app_id_from_tags, tags)
+        self.assertEqual(str(exception),
+                         'Multiple (2) Consular tags found for key '
+                         '"consular-app-id=": [\'consular-app-id=/my-app\', '
+                         '\'consular-app-id=/my-app2\']')
+
     @inlineCallbacks
     def test_service(self):
         response = yield self.request('GET', '/')
@@ -175,8 +211,8 @@ class ConsularTest(TestCase):
             'Address': 'slave-1234.acme.org',
             'Port': 31372,
             'Tags': [
-                'consular-reg-id:test',
-                'consular-app-id:/my-app',
+                'consular-reg-id=test',
+                'consular-app-id=/my-app',
             ],
         }))
         request['deferred'].callback(
@@ -289,8 +325,8 @@ class ConsularTest(TestCase):
             'Address': '0.0.0.0',
             'Port': 1234,
             'Tags': [
-                'consular-reg-id:test',
-                'consular-app-id:/my-app',
+                'consular-reg-id=test',
+                'consular-app-id=/my-app',
             ],
         }))
         self.assertEqual(consul_request['method'], 'PUT')
@@ -317,8 +353,8 @@ class ConsularTest(TestCase):
             'Address': '0.0.0.0',
             'Port': 1234,
             'Tags': [
-                'consular-reg-id:test',
-                'consular-app-id:/my-group/my-app',
+                'consular-reg-id=test',
+                'consular-app-id=/my-group/my-app',
             ],
         }))
         self.assertEqual(consul_request['method'], 'PUT')
@@ -397,8 +433,8 @@ class ConsularTest(TestCase):
                     "Address": "machine-1",
                     "Port": 8102,
                     "Tags": [
-                        "consular-reg-id:test",
-                        "consular-app-id:/testinggroup/someid1",
+                        "consular-reg-id=test",
+                        "consular-app-id=/testinggroup/someid1",
                     ],
                 },
                 "testinggroup-someid1": {
@@ -408,8 +444,8 @@ class ConsularTest(TestCase):
                     "Address": "machine-2",
                     "Port": 8103,
                     "Tags": [
-                        "consular-reg-id:test",
-                        "consular-app-id:/testinggroup/someid1",
+                        "consular-reg-id=test",
+                        "consular-app-id=/testinggroup/someid1",
                     ],
                 }
             }))
@@ -479,8 +515,8 @@ class ConsularTest(TestCase):
                     "ID": "testingapp.someid1",
                     "Service": "testingapp",
                     "Tags": [
-                        "consular-reg-id:test",
-                        "consular-app-id:/testingapp",
+                        "consular-reg-id=test",
+                        "consular-app-id=/testingapp",
                     ],
                     "Address": "machine-1",
                     "Port": 8102
@@ -489,8 +525,8 @@ class ConsularTest(TestCase):
                     "ID": "testingapp.someid2",
                     "Service": "testingapp",
                     "Tags": [
-                        "consular-reg-id:blah",
-                        "consular-app-id:/testingapp",
+                        "consular-reg-id=blah",
+                        "consular-app-id=/testingapp",
                     ],
                     "Address": "machine-2",
                     "Port": 8103
@@ -550,7 +586,7 @@ class ConsularTest(TestCase):
             'Address': 'foo',
             'Port': 1234,
             'Tags': [
-                'consular-reg-id:test',
-                'consular-app-id:/app_id',
+                'consular-reg-id=test',
+                'consular-app-id=/app_id',
             ],
         }))

--- a/consular/tests/test_main.py
+++ b/consular/tests/test_main.py
@@ -174,7 +174,10 @@ class ConsularTest(TestCase):
             'ID': 'my-app_0-1396592784349',
             'Address': 'slave-1234.acme.org',
             'Port': 31372,
-            'Tags': ['consular-reg-id:test'],
+            'Tags': [
+                'consular-reg-id:test',
+                'consular-app-id:/my-app',
+            ],
         }))
         request['deferred'].callback(
             FakeResponse(200, [], json.dumps({})))
@@ -285,7 +288,10 @@ class ConsularTest(TestCase):
             'ID': 'my-task-id',
             'Address': '0.0.0.0',
             'Port': 1234,
-            'Tags': ['consular-reg-id:test'],
+            'Tags': [
+                'consular-reg-id:test',
+                'consular-app-id:/my-app',
+            ],
         }))
         self.assertEqual(consul_request['method'], 'PUT')
         consul_request['deferred'].callback(
@@ -487,7 +493,7 @@ class ConsularTest(TestCase):
     def test_fallback_to_main_consul(self):
         self.consular.enable_fallback = True
         self.consular.register_service(
-            'http://foo:8500', 'app_id', 'service_id', 'foo', 1234)
+            'http://foo:8500', '/app_id', 'service_id', 'foo', 1234)
         request = yield self.requests.get()
         self.assertEqual(
             request['url'],
@@ -506,5 +512,8 @@ class ConsularTest(TestCase):
             'ID': 'service_id',
             'Address': 'foo',
             'Port': 1234,
-            'Tags': ['consular-reg-id:test'],
+            'Tags': [
+                'consular-reg-id:test',
+                'consular-app-id:/app_id',
+            ],
         }))


### PR DESCRIPTION
The purge process passes around the trimmed app name. E.g. for an app with a path like `/mygroup/myapp`, the app is just considered to be `/myapp`.

This means that apps in groups that aren't the root group (`/`) are purged unnecessarily.
