### PR TITLE
Apps in different groups could resolve to same Consul service names

### DIFF
--- a/consular/main.py
+++ b/consular/main.py
@@ -371,12 +371,42 @@ class Consular(object):
         """
         d = self.marathon_request('GET', '/v2/apps')
         d.addCallback(lambda response: response.json())
+        d.addCallback(lambda response_json: response_json['apps'])
+        d.addCallback(self.check_apps_namespace_clash)
         d.addCallback(
-            lambda data: gatherResults(
-                [self.sync_app(app) for app in data['apps']]))
+            lambda apps: gatherResults([self.sync_app(app) for app in apps]))
         if purge:
             d.addCallback(lambda _: self.purge_dead_services())
         return d
+
+    def check_apps_namespace_clash(self, apps):
+        """
+        Checks if app names in Marathon will cause a namespace clash in Consul.
+        Throws an exception if there is a collision, else returns the apps.
+
+        :param: apps:
+            The JSON list of apps from Marathon's API.
+        """
+        # Collect the app name to app id(s) mapping.
+        name_ids = {}
+        for app in apps:
+            app_id = app['id']
+            app_name = get_app_name(app_id)
+            name_ids.setdefault(app_name, []).append(app_id)
+
+        # Check if any app names map to more than one app id.
+        collisions = {name: ids
+                      for name, ids in name_ids.items() if len(ids) > 1}
+
+        if collisions:
+            collisions_string = '\n'.join(sorted(
+                ['%s => %s' % (name, ', '.join(ids),)
+                 for name, ids in collisions.items()]))
+            raise RuntimeError(
+                'The following Consul service name will resolve to multiple '
+                'Marathon app names: \n%s' % (collisions_string,))
+
+        return apps
 
     def get_app(self, app_id):
         d = self.marathon_request('GET', '/v2/apps%s' % (app_id,))

--- a/consular/main.py
+++ b/consular/main.py
@@ -403,8 +403,8 @@ class Consular(object):
                 ['%s => %s' % (name, ', '.join(ids),)
                  for name, ids in collisions.items()]))
             raise RuntimeError(
-                'The following Consul service name will resolve to multiple '
-                'Marathon app names: \n%s' % (collisions_string,))
+                'The following Consul service name(s) will resolve to '
+                'multiple Marathon app names: \n%s' % (collisions_string,))
 
         return apps
 

--- a/consular/tests/test_main.py
+++ b/consular/tests/test_main.py
@@ -441,10 +441,10 @@ class ConsularTest(TestCase):
         exception = self.assertRaises(
             RuntimeError, self.consular.check_apps_namespace_clash, apps)
 
-        self.assertEqual('The following Consul service name will resolve to '
-                         'multiple Marathon app names: \nmy-group-my-subgroup-'
-                         'my-app => /my-group/my-subgroup/my-app, /my-group/my'
-                         '-subgroup-my-app, /my-group-my-subgroup-my-app',
+        self.assertEqual('The following Consul service name(s) will resolve '
+                         'to multiple Marathon app names: \nmy-group-my-subgro'
+                         'up-my-app => /my-group/my-subgroup/my-app, /my-group'
+                         '/my-subgroup-my-app, /my-group-my-subgroup-my-app',
                          str(exception))
 
     @inlineCallbacks

--- a/consular/tests/test_main.py
+++ b/consular/tests/test_main.py
@@ -414,6 +414,39 @@ class ConsularTest(TestCase):
             FakeResponse(200, [], json.dumps({'apps': []})))
         yield d
 
+    def test_check_apps_namespace_clash_no_clash(self):
+        """
+        When checking for app namespace clashes and there are no clashes, the
+        list of apps is returned.
+        """
+        apps = [
+            {'id': '/my-group/my-app'},
+            {'id': '/my-app'},
+            {'id': '/my-group/my-app2'},
+        ]
+        apps_returned = self.consular.check_apps_namespace_clash(apps)
+        self.assertEqual(apps, apps_returned)
+
+    def test_check_apps_namespace_clash_clashing(self):
+        """
+        When checking for app namespace clashes and there are clashes, an
+        error is raised with an error message describing the clashes.
+        """
+        apps = [
+            {'id': '/my-group/my-subgroup/my-app'},
+            {'id': '/my-group/my-subgroup-my-app'},
+            {'id': '/my-group-my-subgroup-my-app'},
+            {'id': '/my-app'},
+        ]
+        exception = self.assertRaises(
+            RuntimeError, self.consular.check_apps_namespace_clash, apps)
+
+        self.assertEqual('The following Consul service name will resolve to '
+                         'multiple Marathon app names: \nmy-group-my-subgroup-'
+                         'my-app => /my-group/my-subgroup/my-app, /my-group/my'
+                         '-subgroup-my-app, /my-group-my-subgroup-my-app',
+                         str(exception))
+
     @inlineCallbacks
     def test_purge_dead_services(self):
         d = self.consular.purge_dead_services()


### PR DESCRIPTION
As a result of #28, apps in different groups could resolve to the same name in Consul. For example, a Marathon app at `/my-group/my-app` and another app at `/my-group-my-app` would resolve to the same name: `my-group-my-app`.

There is not much we can do about this but we should probably warn the user.
