### PR TITLE
Refactor all HTTP requests into client classes

### DIFF
--- a/consular/cli.py
+++ b/consular/cli.py
@@ -61,8 +61,8 @@ def main(scheme, host, port,
     log.startLogging(logfile)
 
     consular = Consular(consul, marathon, fallback, registration_id)
-    consular.debug = debug
-    consular.timeout = timeout
+    consular.set_debug(debug)
+    consular.set_timeout(timeout)
     consular.fallback_timeout = fallback_timeout
     events_url = "%s://%s:%s/events?%s" % (
         scheme, host, port,

--- a/consular/clients.py
+++ b/consular/clients.py
@@ -66,7 +66,6 @@ class MarathonClient(JsonClient):
 
     def _basic_get_request(self, path, field, raise_error=True):
         d = self.marathon_request('GET', path)
-        d.addErrback(log.err)
         d.addCallback(JsonClient.response_json)
         return d.addCallback(self._get_json_field, field, raise_error)
 
@@ -90,7 +89,6 @@ class MarathonClient(JsonClient):
             'POST', '/v2/eventSubscriptions?%s' % urlencode({
                 'callbackUrl': callback_url,
             }))
-        d.addErrback(log.err)
         return d.addCallback(JsonClient.response_ok)
 
     def get_apps(self):

--- a/consular/clients.py
+++ b/consular/clients.py
@@ -1,0 +1,104 @@
+from urllib import urlencode
+import json
+
+from twisted.internet import reactor
+from twisted.python import log
+from twisted.web import client
+
+# Twisted's default HTTP11 client factory is way too verbose
+client._HTTP11ClientFactory.noisy = False
+
+import treq
+
+
+class JsonClient(object):
+    debug = False
+    clock = reactor
+    timeout = 5
+    requester = lambda self, *a, **kw: treq.request(*a, **kw)
+
+    def __init__(self):
+        self.pool = client.HTTPConnectionPool(self.clock, persistent=False)
+
+    def _log_http_response(self, response, method, path, data):
+        log.msg('%s %s with %s returned: %s' % (
+            method, path, data, response.code))
+        return response
+
+    def _log_http_error(self, failure, url):
+        log.err(failure, 'Error performing request to %s' % (url,))
+        return failure
+
+    def request(self, method, url, data, timeout=None):
+        d = self.requester(
+            method,
+            url.encode('utf-8'),
+            headers={
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+            },
+            data=(json.dumps(data) if data is not None else None),
+            pool=self.pool,
+            timeout=timeout or self.timeout)
+
+        if self.debug:
+            d.addCallback(self._log_http_response, method, url, data)
+
+        return d.addErrback(self._log_http_error, url)
+
+    @classmethod
+    def response_json(cls, response):
+        return response.json()
+
+    @classmethod
+    def response_ok(cls, response):
+        return response.code == 200
+
+
+class MarathonClient(JsonClient):
+
+    def __init__(self, endpoint):
+        super(MarathonClient, self).__init__()
+        self.endpoint = endpoint
+
+    def marathon_request(self, method, path, data=None):
+        return self.request(method, '%s%s' % (self.endpoint, path), data)
+
+    def _basic_get_request(self, path, field, raise_error=True):
+        d = self.marathon_request('GET', path)
+        d.addErrback(log.err)
+        d.addCallback(JsonClient.response_json)
+        return d.addCallback(self._get_json_field, field, raise_error)
+
+    def _get_json_field(self, response_json, field_name, raise_error=True):
+        if field_name not in response_json:
+            if raise_error:
+                raise KeyError('Unable to get value for "%s" from Marathon '
+                               'response: "%s"' % (
+                                   field_name, str(response_json),))
+            else:
+                return None
+
+        return response_json[field_name]
+
+    def get_event_subscriptions(self):
+        return self._basic_get_request(
+            '/v2/eventSubscriptions', 'callbackUrls')
+
+    def post_event_subscription(self, callback_url):
+        d = self.marathon_request(
+            'POST', '/v2/eventSubscriptions?%s' % urlencode({
+                'callbackUrl': callback_url,
+            }))
+        d.addErrback(log.err)
+        return d.addCallback(JsonClient.response_ok)
+
+    def get_apps(self):
+        return self._basic_get_request('/v2/apps', 'apps')
+
+    def get_app(self, app_id):
+        return self._basic_get_request('/v2/apps%s' % (app_id,), 'app')
+
+    def get_app_tasks(self, app_id, raise_error=True):
+        return self._basic_get_request(
+            '/v2/apps%s/tasks' % (app_id,), 'tasks', raise_error)

--- a/consular/clients.py
+++ b/consular/clients.py
@@ -17,7 +17,8 @@ class JsonClient(object):
     timeout = 5
     requester = lambda self, *a, **kw: treq.request(*a, **kw)
 
-    def __init__(self):
+    def __init__(self, endpoint):
+        self.endpoint = endpoint
         self.pool = client.HTTPConnectionPool(self.clock, persistent=False)
 
     def _log_http_response(self, response, method, path, data):
@@ -29,44 +30,60 @@ class JsonClient(object):
         log.err(failure, 'Error performing request to %s' % (url,))
         return failure
 
-    def request(self, method, url, data=None, timeout=None):
-        d = self.requester(
-            method,
-            url.encode('utf-8'),
-            headers={
+    def request(self, method, path, endpoint=None, json_data=None, **kwargs):
+        """
+        Perform a request. A number of basic defaults are set on the request
+        that make using a JSON API easier.
+
+        :param: method:
+            The HTTP method to use (example is `GET`).
+        :param: path:
+            The URL path. This is appended to the endpoint and should start
+            with a '/' (example is `/v2/apps`).
+        :param: endpoint:
+            The URL endpoint to use. The default value is the endpoint this
+            client was created with (`self.endpoint`) (example is
+            `http://localhost:8080`)
+        :param: json_data:
+            A python data structure that will be converted to a JSON string
+            using `json.dumps` and used as the request body.
+        :param: kwargs:
+            Any other parameters that will be passed to `treq.request`, for
+            example headers or parameters.
+        """
+        url = ('%s%s' % (endpoint or self.endpoint, path)).encode('utf-8')
+
+        data = json.dumps(json_data) if json_data else None
+        requester_kwargs = {
+            'headers': {
                 'Content-Type': 'application/json',
                 'Accept': 'application/json',
             },
-            data=(json.dumps(data) if data is not None else None),
-            pool=self.pool,
-            timeout=timeout or self.timeout)
+            'data': data,
+            'pool': self.pool,
+            'timeout': self.timeout
+        }
+        requester_kwargs.update(kwargs)
+
+        d = self.requester(method, url, **requester_kwargs)
 
         if self.debug:
             d.addCallback(self._log_http_response, method, url, data)
 
         return d.addErrback(self._log_http_error, url)
 
-    @classmethod
-    def response_json(cls, response):
-        return response.json()
-
-    @classmethod
-    def response_ok(cls, response):
-        return response.code == 200
+    def get_json(self, path, **kwargs):
+        """
+        Perform a GET request to the given path and return the JSON response.
+        """
+        d = self.request('GET', path, **kwargs)
+        return d.addCallback(lambda response: response.json())
 
 
 class MarathonClient(JsonClient):
 
-    def __init__(self, endpoint):
-        super(MarathonClient, self).__init__()
-        self.endpoint = endpoint
-
-    def marathon_request(self, method, path, data=None):
-        return self.request(method, '%s%s' % (self.endpoint, path), data)
-
     def _basic_get_request(self, path, field, raise_error=True):
-        d = self.marathon_request('GET', path)
-        d.addCallback(JsonClient.response_json)
+        d = self.get_json(path)
         return d.addCallback(self._get_json_field, field, raise_error)
 
     def _get_json_field(self, response_json, field_name, raise_error=True):
@@ -85,11 +102,11 @@ class MarathonClient(JsonClient):
             '/v2/eventSubscriptions', 'callbackUrls')
 
     def post_event_subscription(self, callback_url):
-        d = self.marathon_request(
+        d = self.request(
             'POST', '/v2/eventSubscriptions?%s' % urlencode({
                 'callbackUrl': callback_url,
             }))
-        return d.addCallback(JsonClient.response_ok)
+        return d.addCallback(lambda response: response.code == 200)
 
     def get_apps(self):
         return self._basic_get_request('/v2/apps', 'apps')
@@ -107,23 +124,13 @@ class ConsulClient(JsonClient):
     fallback_timeout = 2
 
     def __init__(self, endpoint, enable_fallback=False):
-        super(ConsulClient, self).__init__()
+        super(ConsulClient, self).__init__(endpoint)
         self.endpoint = endpoint
         self.enable_fallback = enable_fallback
 
-    def consul_request(self, method, path, endpoint=None, data=None,
-                       timeout=None):
-        if not endpoint:
-            endpoint = self.endpoint
-        if not timeout:
-            timeout = self.timeout
-
-        return self.request(
-            method, '%s%s' % (endpoint, path,), data=data, timeout=timeout)
-
     def register_agent_service(self, agent_endpoint, registration):
-        d = self.consul_request('PUT', '/v1/agent/service/register',
-                                endpoint=agent_endpoint, data=registration)
+        d = self.request('PUT', '/v1/agent/service/register',
+                         endpoint=agent_endpoint, json_data=registration)
 
         if self.enable_fallback:
             d.addErrback(self.register_agent_service_fallback, registration)
@@ -133,35 +140,31 @@ class ConsulClient(JsonClient):
     def register_agent_service_fallback(self, failure, registration):
         log.msg('Falling back for %s at %s.' % (
             registration['Name'], self.endpoint))
-        return self.consul_request(
-            'PUT', '/v1/agent/service/register',  data=registration,
+        return self.request(
+            'PUT', '/v1/agent/service/register',  json_data=registration,
             timeout=self.fallback_timeout)
 
     def deregister_agent_service(self, agent_endpoint, service_id):
-        return self.consul_request('PUT', '/v1/agent/service/deregister/%s' % (
+        return self.request('PUT', '/v1/agent/service/deregister/%s' % (
             service_id,), endpoint=agent_endpoint)
 
     def put_kv(self, key, value):
-        return self.consul_request(
-            'PUT', '/v1/kv/%s' % (quote(key),), data=value)
+        return self.request(
+            'PUT', '/v1/kv/%s' % (quote(key),), json_data=value)
 
     def get_kv_keys(self, keys_path, separator=None):
         params = {'keys': ''}
         if separator:
             params['separator'] = separator
-        d = self.consul_request('GET', '/v1/kv/%s?%s' % (
-            quote(keys_path), urlencode(params)))
-        return d.addCallback(JsonClient.response_json)
+        return self.get_json('/v1/kv/%s?%s' % (quote(keys_path),
+                                               urlencode(params)))
 
     def delete_kv_keys(self, key, recurse=False):
-        return self.consul_request('DELETE', '/v1/kv/%s%s' % (
+        return self.request('DELETE', '/v1/kv/%s%s' % (
             quote(key), '?recurse' if recurse else '',))
 
     def get_catalog_nodes(self):
-        d = self.consul_request('GET', '/v1/catalog/nodes')
-        return d.addCallback(JsonClient.response_json)
+        return self.get_json('/v1/catalog/nodes')
 
     def get_agent_services(self, agent_endpoint):
-        d = self.consul_request(
-            'GET', '/v1/agent/services', endpoint=agent_endpoint)
-        return d.addCallback(JsonClient.response_json)
+        return self.get_json('/v1/agent/services', endpoint=agent_endpoint)

--- a/consular/clients.py
+++ b/consular/clients.py
@@ -37,7 +37,8 @@ class JsonClient(object):
     def request(self, method, path, endpoint=None, json_data=None, **kwargs):
         """
         Perform a request. A number of basic defaults are set on the request
-        that make using a JSON API easier.
+        that make using a JSON API easier. These defaults can be overridden by
+        setting the parameters in the keyword args.
 
         :param: method:
             The HTTP method to use (example is `GET`).

--- a/consular/tests/test_main.py
+++ b/consular/tests/test_main.py
@@ -45,7 +45,7 @@ class ConsularTest(TestCase):
             False,
             'test'
         )
-        self.consular.debug = True
+        self.consular.set_debug(True)
 
         # spin up a site so we can test it, pretty sure Klein has better
         # ways of doing this but they're not documented anywhere.
@@ -71,7 +71,7 @@ class ConsularTest(TestCase):
             })
             return d
 
-        self.patch(self.consular, 'requester', mock_requests)
+        self.consular.set_requester(mock_requests)
 
     def request(self, method, path, data=None):
         return treq.request(
@@ -316,17 +316,17 @@ class ConsularTest(TestCase):
         list_callbacks_request['deferred'].callback(
             FakeResponse(400, [], json.dumps({
                 'message':
-                'http event callback system is not running on this Marathon ' +
-                'instance. Please re-start this instance with ' +
+                'http event callback system is not running on this Marathon '
+                'instance. Please re-start this instance with '
                 '"--event_subscriber http_callback".'})))
 
-        failure = self.failureResultOf(d, RuntimeError)
+        failure = self.failureResultOf(d, KeyError)
         self.assertEqual(
             failure.getErrorMessage(),
-            'Unable to get existing event callbacks from Marathon: ' +
-            '\'{u\\\'message\\\': u\\\'http event callback system is not ' +
-            'running on this Marathon instance. Please re-start this ' +
-            'instance with "--event_subscriber http_callback".\\\'}\'')
+            '\'Unable to get value for "callbackUrls" from Marathon response: '
+            '"{u\\\'message\\\': u\\\'http event callback system is not '
+            'running on this Marathon instance. Please re-start this instance '
+            'with "--event_subscriber http_callback".\\\'}"\'')
 
     @inlineCallbacks
     def test_sync_app_task(self):

--- a/consular/tests/test_main.py
+++ b/consular/tests/test_main.py
@@ -61,12 +61,12 @@ class ConsularTest(TestCase):
         # We use this to mock requests going to Consul & Marathon
         self.requests = DeferredQueue()
 
-        def mock_requests(method, url, headers, data, pool, timeout):
+        def mock_requests(method, url, **kwargs):
             d = Deferred()
             self.requests.put({
                 'method': method,
                 'url': url,
-                'data': data,
+                'data': kwargs.get('data'),
                 'deferred': d,
             })
             return d

--- a/consular/tests/test_main.py
+++ b/consular/tests/test_main.py
@@ -559,8 +559,8 @@ class ConsularTest(TestCase):
     def test_sync_apps_field_not_found(self):
         """
         When syncing apps, and Marathon returns a JSON response with an
-        unexpected structure (the "apps" field is missing. A KeyError should
-        be raised.
+        unexpected structure (the "apps" field is missing). A KeyError should
+        be raised with a useful message.
         """
         d = self.consular.sync_apps(purge=False)
         marathon_request = yield self.requests.get()

--- a/consular/tests/test_main.py
+++ b/consular/tests/test_main.py
@@ -9,6 +9,7 @@ from twisted.internet.defer import (
 from twisted.web.client import HTTPConnectionPool
 from twisted.python import log
 
+from consular.clients import UnexpectedResponseError
 from consular.main import Consular
 
 import treq
@@ -320,13 +321,13 @@ class ConsularTest(TestCase):
                 'instance. Please re-start this instance with '
                 '"--event_subscriber http_callback".'})))
 
-        failure = self.failureResultOf(d, KeyError)
+        failure = self.failureResultOf(d, UnexpectedResponseError)
         self.assertEqual(
             failure.getErrorMessage(),
-            '\'Unable to get value for "callbackUrls" from Marathon response: '
-            '"{u\\\'message\\\': u\\\'http event callback system is not '
-            'running on this Marathon instance. Please re-start this instance '
-            'with "--event_subscriber http_callback".\\\'}"\'')
+            'response: code=400, body={"message": "http event callback system '
+            'is not running on this Marathon instance. Please re-start this '
+            'instance with \\"--event_subscriber http_callback\\"."} '
+            '\nrequest: method=, url=, body=')
 
     @inlineCallbacks
     def test_sync_app_task(self):
@@ -508,11 +509,10 @@ class ConsularTest(TestCase):
         # Error is raised into a DeferredList, must get actual error
         failure = self.failureResultOf(d, FirstError)
         actual_failure = failure.value.subFailure
-        self.assertEqual(actual_failure.type, RuntimeError)
+        self.assertEqual(actual_failure.type, UnexpectedResponseError)
         self.assertEqual(
             actual_failure.getErrorMessage(),
-            'Unexpected response from Consul when getting keys for '
-            '"consular/my-app", status code = 403')
+            'response: code=403, body=None \nrequest: method=, url=, body=')
 
     @inlineCallbacks
     def test_sync_app(self):
@@ -554,6 +554,29 @@ class ConsularTest(TestCase):
         marathon_request['deferred'].callback(
             FakeResponse(200, [], json.dumps({'apps': []})))
         yield d
+
+    @inlineCallbacks
+    def test_sync_apps_field_not_found(self):
+        """
+        When syncing apps, and Marathon returns a JSON response with an
+        unexpected structure (the "apps" field is missing. A KeyError should
+        be raised.
+        """
+        d = self.consular.sync_apps(purge=False)
+        marathon_request = yield self.requests.get()
+        self.assertEqual(marathon_request['url'],
+                         'http://localhost:8080/v2/apps')
+        self.assertEqual(marathon_request['method'], 'GET')
+        marathon_request['deferred'].callback(
+            FakeResponse(200, [], json.dumps({
+                'some field': 'that was unexpected'
+            })))
+
+        failure = self.failureResultOf(d, KeyError)
+        self.assertEqual(
+            failure.getErrorMessage(),
+            '\'Unable to get value for "apps" from Marathon response: "{"some '
+            'field": "that was unexpected"}"\'')
 
     def test_check_apps_namespace_clash_no_clash(self):
         """
@@ -731,8 +754,85 @@ class ConsularTest(TestCase):
                          'http://localhost:8080/v2/apps/testingapp/tasks')
         self.assertEqual(testingapp_request['method'], 'GET')
         testingapp_request['deferred'].callback(
-            FakeResponse(200, [], json.dumps({}))
+            FakeResponse(200, [], json.dumps({'tasks': []})))
+
+        # Expecting a service deregistering in Consul as a result. Only the
+        # task with the correct tag is returned.
+        deregister_request = yield self.requests.get()
+        self.assertEqual(
+            deregister_request['url'],
+            ('http://1.2.3.4:8500/v1/agent/service/deregister/'
+             'testingapp.someid1'))
+        self.assertEqual(deregister_request['method'], 'PUT')
+        deregister_request['deferred'].callback(
+            FakeResponse(200, [], json.dumps({})))
+        yield d
+
+    @inlineCallbacks
+    def test_purge_old_services_tasks_not_found(self):
+        """
+        Services previously registered with Consul by Consular but that no
+        longer exist in Marathon should be purged if a registration ID is set,
+        even if the tasks are not found.
+        """
+        d = self.consular.purge_dead_services()
+        consul_request = yield self.requests.get()
+        self.assertEqual(
+            consul_request['url'],
+            'http://localhost:8500/v1/catalog/nodes')
+        consul_request['deferred'].callback(
+            FakeResponse(200, [], json.dumps([{
+                'Node': 'consul-node',
+                'Address': '1.2.3.4',
+            }]))
         )
+        agent_request = yield self.requests.get()
+        # Expecting a request to list of all services in Consul, returning 3
+        # services - one tagged with our registration ID, one tagged with a
+        # different registration ID, and one with no tags.
+        self.assertEqual(
+            agent_request['url'],
+            'http://1.2.3.4:8500/v1/agent/services')
+        self.assertEqual(agent_request['method'], 'GET')
+        agent_request['deferred'].callback(
+            FakeResponse(200, [], json.dumps({
+                "testingapp.someid1": {
+                    "ID": "testingapp.someid1",
+                    "Service": "testingapp",
+                    "Tags": [
+                        "consular-reg-id=test",
+                        "consular-app-id=/testingapp",
+                    ],
+                    "Address": "machine-1",
+                    "Port": 8102
+                },
+                "testingapp.someid2": {
+                    "ID": "testingapp.someid2",
+                    "Service": "testingapp",
+                    "Tags": [
+                        "consular-reg-id=blah",
+                        "consular-app-id=/testingapp",
+                    ],
+                    "Address": "machine-2",
+                    "Port": 8103
+                },
+                "testingapp.someid3": {
+                    "ID": "testingapp.someid2",
+                    "Service": "testingapp",
+                    "Tags": None,
+                    "Address": "machine-2",
+                    "Port": 8104
+                }
+            }))
+        )
+
+        # Expecting a request for the tasks for a given app, returning a 404
+        testingapp_request = yield self.requests.get()
+        self.assertEqual(testingapp_request['url'],
+                         'http://localhost:8080/v2/apps/testingapp/tasks')
+        self.assertEqual(testingapp_request['method'], 'GET')
+        testingapp_request['deferred'].callback(
+            FakeResponse(404, [], None))
 
         # Expecting a service deregistering in Consul as a result. Only the
         # task with the correct tag is returned.
@@ -856,11 +956,10 @@ class ConsularTest(TestCase):
         # Return a 403 error
         consul_request['deferred'].callback(FakeResponse(403, [], None))
 
-        failure = self.failureResultOf(d, RuntimeError)
+        failure = self.failureResultOf(d, UnexpectedResponseError)
         self.assertEqual(
             failure.getErrorMessage(),
-            'Unexpected response from Consul when getting keys for '
-            '"consular/", status code = 403')
+            'response: code=403, body=None \nrequest: method=, url=, body=')
 
     @inlineCallbacks
     def test_fallback_to_main_consul(self):

--- a/consular/tests/test_main.py
+++ b/consular/tests/test_main.py
@@ -760,7 +760,7 @@ class ConsularTest(TestCase):
 
     @inlineCallbacks
     def test_fallback_to_main_consul(self):
-        self.consular.enable_fallback = True
+        self.consular.consul_client.enable_fallback = True
         self.consular.register_service(
             'http://foo:8500', '/app_id', 'service_id', 'foo', 1234)
         request = yield self.requests.get()


### PR DESCRIPTION
Supersedes #35, comparing against `develop` this time.
