### PR TITLE
Example template sometimes has problem with keys not found

### DIFF
--- a/templates/nginx.ctmpl
+++ b/templates/nginx.ctmpl
@@ -7,7 +7,7 @@
 #       Nginx. If the key does not exist the service isn't added to the
 #       list of services in the Nginx config.
 
-{{range services}}{{$labels = ls (print "consular/" .Name) | explode }}{{if $labels.domain}}
+{{range services}}{{$labels := ls (print "consular/" .Name) | explode }}{{if $labels.domain}}
 
 upstream {{.Name}} {
   {{range service .Name }}server {{.Address}}:{{.Port}};


### PR DESCRIPTION
`template: template: nginx.ctmpl:10: undefined variable "$labels"2015/10/13 17:02:07`

~~`$labels` is not defined when we try to access `$labels.domain`~~
