### PR TITLE
Accept non-200 code responses

### DIFF
--- a/consular/main.py
+++ b/consular/main.py
@@ -1,7 +1,6 @@
 import json
 
-from consular.clients import (
-    ConsulClient, MarathonClient, UnexpectedResponseError)
+from consular.clients import ConsulClient, MarathonClient, HTTPError
 
 from twisted.internet import reactor
 from twisted.web import server
@@ -38,7 +37,7 @@ def handle_not_found_error(f, *args, **kwargs):
     """
     try:
         response = yield f(*args, **kwargs)
-    except UnexpectedResponseError as e:
+    except HTTPError as e:
         if e.response.code == NOT_FOUND:
             response = None
         else:


### PR DESCRIPTION
At the moment we only accept 200 response codes but other 2xx codes are acceptable too.

Do something like requests: https://github.com/kennethreitz/requests/blob/v2.8.1/requests/models.py#L825-L837
