### PR TITLE
Ensure all errors handled when syncing apps

### DIFF
--- a/consular/cli.py
+++ b/consular/cli.py
@@ -54,7 +54,6 @@ def main(scheme, host, port,
          sync_interval, purge, logfile, debug, timeout,
          fallback, fallback_timeout):  # pragma: no cover
     from consular.main import Consular
-    from twisted.internet.task import LoopingCall
     from twisted.internet import reactor
     from twisted.python import log
 
@@ -72,8 +71,7 @@ def main(scheme, host, port,
     consular.register_marathon_event_callback(events_url)
 
     if sync_interval > 0:
-        lc = LoopingCall(consular.sync_apps, purge)
-        lc.start(sync_interval, now=True)
+        consular.schedule_sync(sync_interval, purge)
 
     consular.run(host, port)
     reactor.run()

--- a/consular/main.py
+++ b/consular/main.py
@@ -118,9 +118,13 @@ class Consular(object):
             The number of seconds between syncs.
         :param bool purge:
             Whether to purge old apps after each sync.
+        :return:
+            A tuple of the LoopingCall object and the deferred created when it
+            was started.
         """
         lc = LoopingCall(self.sync_apps, purge)
-        lc.start(interval, now=True)
+        lc.clock = self.clock
+        return (lc, lc.start(interval, now=True))
 
     @inlineCallbacks
     def register_marathon_event_callback(self, events_url):

--- a/consular/main.py
+++ b/consular/main.py
@@ -122,9 +122,20 @@ class Consular(object):
             A tuple of the LoopingCall object and the deferred created when it
             was started.
         """
-        lc = LoopingCall(self.sync_apps, purge)
+        lc = LoopingCall(self._try_sync_apps, purge)
         lc.clock = self.clock
         return (lc, lc.start(interval, now=True))
+
+    @inlineCallbacks
+    def _try_sync_apps(self, purge=False):
+        """
+        Sync the apps, catching and logging any exception that occurs.
+        """
+        try:
+            yield self.sync_apps(purge)
+        except Exception as e:
+            # TODO: More specialised exception handling.
+            log.msg('Error syncing apps: %s' % e)
 
     @inlineCallbacks
     def register_marathon_event_callback(self, events_url):


### PR DESCRIPTION
There seems to be a problem where the looping call to sync apps doesn't schedule a new sync, probably after an error occurs.

This means the syncing/purging of apps stops working on the node.
