### PR TITLE
Consular crashes if a Marathon task has no ports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 _trial_temp/
 /docs/_build
 htmlcov/
+.cache/

--- a/consular/main.py
+++ b/consular/main.py
@@ -227,7 +227,7 @@ class Consular(object):
         """ Use a running event to register a new Consul service. """
         # Register the task as a service
         yield self.register_task_service(
-            event['appId'], event['taskId'], event['host'], event['ports'][0])
+            event['appId'], event['taskId'], event['host'], event['ports'])
 
         # Sync the app labels in case they've changed or aren't stored yet
         app = yield handle_not_found_error(
@@ -300,15 +300,17 @@ class Consular(object):
             'Name': get_app_name(app_id),
             'ID': service_id,
             'Address': address,
-            'Port': port,
             'Tags': [
                 self.reg_id_tag(),
                 self.app_id_tag(app_id),
             ]
         }
+        if port is not None:
+            registration['Port'] = port
+
         return registration
 
-    def register_task_service(self, app_id, task_id, host, port):
+    def register_task_service(self, app_id, task_id, host, ports):
         """
         Register a Marathon task as a service in Consul.
 
@@ -318,9 +320,20 @@ class Consular(object):
             The ID of the task, this will be used as the Consul service ID.
         :param str host:
             The host address of the machine the task is running on.
-        :param int port:
-            The port number the task can be accessed on on the host machine.
+        :param list ports:
+            The port numbers the task can be accessed on on the host machine.
         """
+        if not ports:
+            port = None
+        elif len(ports) == 1:
+            [port] = ports
+        else:
+            # TODO: Support multiple ports (issue #29)
+            port = sorted(ports)[0]
+            log.msg('Warning. %d ports found for app "%s". Consular currently '
+                    'only supports a single port. Only the lowest port (%s) '
+                    'will be used.' % (len(ports), app_id, port,))
+
         agent_endpoint = get_agent_endpoint(host)
         log.msg('Registering %s at %s with %s at %s:%s.' % (
             app_id, agent_endpoint, task_id, host, port))
@@ -519,7 +532,7 @@ class Consular(object):
         tasks = yield self.marathon_client.get_app_tasks(app['id'])
         for task in tasks:
             yield self.register_task_service(
-                app['id'], task['id'], task['host'], task['ports'][0])
+                app['id'], task['id'], task['host'], task['ports'])
 
     @inlineCallbacks
     def purge_dead_app_labels(self, apps):

--- a/consular/main.py
+++ b/consular/main.py
@@ -329,7 +329,7 @@ class Consular(object):
             [port] = ports
         else:
             # TODO: Support multiple ports (issue #29)
-            port = sorted(ports)[0]
+            port = min(ports)
             log.msg('Warning. %d ports found for app "%s". Consular currently '
                     'only supports a single port. Only the lowest port (%s) '
                     'will be used.' % (len(ports), app_id, port,))

--- a/consular/tests/test_main.py
+++ b/consular/tests/test_main.py
@@ -341,6 +341,69 @@ class ConsularTest(TestCase):
         })
 
     @inlineCallbacks
+    def test_TASK_RUNNING_multiple_ports(self):
+        """
+        When a TASK_RUNNING event is received from Marathon, and the task has
+        multiple ports, the task should be registered as a service in Consul
+        with the lowest port.
+        """
+        d = self.request('POST', '/events', {
+            "eventType": "status_update_event",
+            "timestamp": "2014-03-01T23:29:30.158Z",
+            "slaveId": "20140909-054127-177048842-5050-1494-0",
+            "taskId": "my-app_0-1396592784349",
+            "taskStatus": "TASK_RUNNING",
+            "appId": "/my-app",
+            "host": "slave-1234.acme.org",
+            "ports": [4567, 1234, 6789],
+            "version": "2014-04-04T06:26:23.051Z"
+        })
+
+        # Store the task as a service in Consul with the lowest port
+        consul_request = yield self.requests.get()
+        self.assertEqual(consul_request['method'], 'PUT')
+        self.assertEqual(
+            consul_request['url'],
+            'http://slave-1234.acme.org:8500/v1/agent/service/register')
+        self.assertEqual(consul_request['data'], json.dumps({
+            'Name': 'my-app',
+            'ID': 'my-app_0-1396592784349',
+            'Address': 'slave-1234.acme.org',
+            'Port': 1234,
+            'Tags': [
+                'consular-reg-id=test',
+                'consular-app-id=/my-app',
+            ],
+        }))
+        consul_request['deferred'].callback(
+            FakeResponse(200, [], json.dumps({})))
+
+        # We should get the app info for the event
+        marathon_app_request = yield self.requests.get()
+        self.assertEqual(marathon_app_request['method'], 'GET')
+        self.assertEqual(marathon_app_request['url'],
+                         'http://localhost:8080/v2/apps/my-app')
+        marathon_app_request['deferred'].callback(
+            FakeResponse(200, [], json.dumps({
+                'app': {
+                    'id': '/my-app',
+                }
+            })))
+
+        # Check if any existing labels stored in Consul
+        consul_kv_request = yield self.requests.get()
+        self.assertEqual(consul_kv_request['method'], 'GET')
+        self.assertEqual(consul_kv_request['url'],
+                         'http://localhost:8500/v1/kv/consular/my-app?keys=')
+        consul_kv_request['deferred'].callback(
+            FakeResponse(200, [], json.dumps([])))
+
+        response = yield d
+        self.assertEqual((yield response.json()), {
+            'status': 'ok'
+        })
+
+    @inlineCallbacks
     def test_TASK_KILLED(self):
         d = self.request('POST', '/events', {
             "eventType": "status_update_event",
@@ -616,6 +679,53 @@ class ConsularTest(TestCase):
             'Name': 'my-app',
             'ID': 'my-task-id',
             'Address': '0.0.0.0',
+            'Tags': [
+                'consular-reg-id=test',
+                'consular-app-id=/my-app',
+            ],
+        }))
+        self.assertEqual(consul_request['method'], 'PUT')
+        consul_request['deferred'].callback(
+            FakeResponse(200, [], json.dumps({})))
+        yield d
+
+    @inlineCallbacks
+    def test_sync_app_tasks_multiple_ports(self):
+        """
+        When syncing an app with a task with multiple ports, Consul is updated
+        with a service entry for the task with the lowest port.
+        """
+        d = self.consular.sync_app_tasks({'id': '/my-app'})
+
+        # First Consular fetches the tasks for the app
+        marathon_request = yield self.requests.get()
+        self.assertEqual(marathon_request['method'], 'GET')
+        self.assertEqual(
+            marathon_request['url'],
+            'http://localhost:8080/v2/apps/my-app/tasks')
+
+        # Respond with one task
+        marathon_request['deferred'].callback(
+            FakeResponse(200, [], json.dumps({
+                'tasks': [
+                    {
+                        'id': 'my-task-id',
+                        'host': '0.0.0.0',
+                        'ports': [4567, 1234, 6789]
+                    }
+                ]}))
+        )
+
+        # Consular should register the task in Consul with the lowest port
+        consul_request = yield self.requests.get()
+        self.assertEqual(
+            consul_request['url'],
+            'http://0.0.0.0:8500/v1/agent/service/register')
+        self.assertEqual(consul_request['data'], json.dumps({
+            'Name': 'my-app',
+            'ID': 'my-task-id',
+            'Address': '0.0.0.0',
+            'Port': 1234,
             'Tags': [
                 'consular-reg-id=test',
                 'consular-app-id=/my-app',

--- a/consular/tests/test_main.py
+++ b/consular/tests/test_main.py
@@ -1210,7 +1210,7 @@ class ConsularTest(TestCase):
     def test_fallback_to_main_consul(self):
         self.consular.consul_client.enable_fallback = True
         self.consular.register_task_service(
-            '/app_id', 'service_id', 'foo', 1234)
+            '/app_id', 'service_id', 'foo', [1234])
         request = yield self.requests.get()
         self.assertEqual(
             request['url'],

--- a/consular/tests/test_main.py
+++ b/consular/tests/test_main.py
@@ -193,7 +193,7 @@ class ConsularTest(TestCase):
         self.assertEqual(
             consul_request['url'],
             'http://slave-1234.acme.org:8500/v1/agent/service/register')
-        self.assertEqual(consul_request['data'], json.dumps({
+        self.assertEqual(json.loads(consul_request['data']), {
             'Name': 'my-app',
             'ID': 'my-app_0-1396592784349',
             'Address': 'slave-1234.acme.org',
@@ -202,7 +202,7 @@ class ConsularTest(TestCase):
                 'consular-reg-id=test',
                 'consular-app-id=/my-app',
             ],
-        }))
+        })
         consul_request['deferred'].callback(
             FakeResponse(200, [], json.dumps({})))
 
@@ -251,7 +251,7 @@ class ConsularTest(TestCase):
         self.assertEqual(
             consul_request['url'],
             'http://slave-1234.acme.org:8500/v1/agent/service/register')
-        self.assertEqual(consul_request['data'], json.dumps({
+        self.assertEqual(json.loads(consul_request['data']), {
             'Name': 'my-app',
             'ID': 'my-app_0-1396592784349',
             'Address': 'slave-1234.acme.org',
@@ -260,7 +260,7 @@ class ConsularTest(TestCase):
                 'consular-reg-id=test',
                 'consular-app-id=/my-app',
             ],
-        }))
+        })
         consul_request['deferred'].callback(
             FakeResponse(200, [], json.dumps({})))
 
@@ -303,7 +303,7 @@ class ConsularTest(TestCase):
         self.assertEqual(
             consul_request['url'],
             'http://slave-1234.acme.org:8500/v1/agent/service/register')
-        self.assertEqual(consul_request['data'], json.dumps({
+        self.assertEqual(json.loads(consul_request['data']), {
             'Name': 'my-app',
             'ID': 'my-app_0-1396592784349',
             'Address': 'slave-1234.acme.org',
@@ -311,7 +311,7 @@ class ConsularTest(TestCase):
                 'consular-reg-id=test',
                 'consular-app-id=/my-app',
             ],
-        }))
+        })
         consul_request['deferred'].callback(
             FakeResponse(200, [], json.dumps({})))
 
@@ -365,7 +365,7 @@ class ConsularTest(TestCase):
         self.assertEqual(
             consul_request['url'],
             'http://slave-1234.acme.org:8500/v1/agent/service/register')
-        self.assertEqual(consul_request['data'], json.dumps({
+        self.assertEqual(json.loads(consul_request['data']), {
             'Name': 'my-app',
             'ID': 'my-app_0-1396592784349',
             'Address': 'slave-1234.acme.org',
@@ -374,7 +374,7 @@ class ConsularTest(TestCase):
                 'consular-reg-id=test',
                 'consular-app-id=/my-app',
             ],
-        }))
+        })
         consul_request['deferred'].callback(
             FakeResponse(200, [], json.dumps({})))
 
@@ -589,7 +589,7 @@ class ConsularTest(TestCase):
         self.assertEqual(
             consul_request['url'],
             'http://0.0.0.0:8500/v1/agent/service/register')
-        self.assertEqual(consul_request['data'], json.dumps({
+        self.assertEqual(json.loads(consul_request['data']), {
             'Name': 'my-app',
             'ID': 'my-task-id',
             'Address': '0.0.0.0',
@@ -598,7 +598,7 @@ class ConsularTest(TestCase):
                 'consular-reg-id=test',
                 'consular-app-id=/my-app',
             ],
-        }))
+        })
         self.assertEqual(consul_request['method'], 'PUT')
         consul_request['deferred'].callback(
             FakeResponse(200, [], json.dumps({})))
@@ -632,7 +632,7 @@ class ConsularTest(TestCase):
         self.assertEqual(
             consul_request['url'],
             'http://0.0.0.0:8500/v1/agent/service/register')
-        self.assertEqual(consul_request['data'], json.dumps({
+        self.assertEqual(json.loads(consul_request['data']), {
             'Name': 'my-group-my-app',
             'ID': 'my-task-id',
             'Address': '0.0.0.0',
@@ -641,7 +641,7 @@ class ConsularTest(TestCase):
                 'consular-reg-id=test',
                 'consular-app-id=/my-group/my-app',
             ],
-        }))
+        })
         self.assertEqual(consul_request['method'], 'PUT')
         consul_request['deferred'].callback(
             FakeResponse(200, [], json.dumps({})))
@@ -675,7 +675,7 @@ class ConsularTest(TestCase):
         self.assertEqual(
             consul_request['url'],
             'http://0.0.0.0:8500/v1/agent/service/register')
-        self.assertEqual(consul_request['data'], json.dumps({
+        self.assertEqual(json.loads(consul_request['data']), {
             'Name': 'my-app',
             'ID': 'my-task-id',
             'Address': '0.0.0.0',
@@ -683,7 +683,7 @@ class ConsularTest(TestCase):
                 'consular-reg-id=test',
                 'consular-app-id=/my-app',
             ],
-        }))
+        })
         self.assertEqual(consul_request['method'], 'PUT')
         consul_request['deferred'].callback(
             FakeResponse(200, [], json.dumps({})))
@@ -721,7 +721,7 @@ class ConsularTest(TestCase):
         self.assertEqual(
             consul_request['url'],
             'http://0.0.0.0:8500/v1/agent/service/register')
-        self.assertEqual(consul_request['data'], json.dumps({
+        self.assertEqual(json.loads(consul_request['data']), {
             'Name': 'my-app',
             'ID': 'my-task-id',
             'Address': '0.0.0.0',
@@ -730,7 +730,7 @@ class ConsularTest(TestCase):
                 'consular-reg-id=test',
                 'consular-app-id=/my-app',
             ],
-        }))
+        })
         self.assertEqual(consul_request['method'], 'PUT')
         consul_request['deferred'].callback(
             FakeResponse(200, [], json.dumps({})))
@@ -1334,7 +1334,7 @@ class ConsularTest(TestCase):
         self.assertEqual(
             fallback_request['url'],
             'http://localhost:8500/v1/agent/service/register')
-        self.assertEqual(fallback_request['data'], json.dumps({
+        self.assertEqual(json.loads(fallback_request['data']), {
             'Name': 'app_id',
             'ID': 'service_id',
             'Address': 'foo',
@@ -1343,4 +1343,4 @@ class ConsularTest(TestCase):
                 'consular-reg-id=test',
                 'consular-app-id=/app_id',
             ],
-        }))
+        })


### PR DESCRIPTION
Related to #29.
We hardcode it... `task['port'][0]`
