### PR TITLE
Consul agents not on port 8500 not supported

### DIFF
--- a/consular/cli.py
+++ b/consular/cli.py
@@ -1,7 +1,7 @@
 import click
 import sys
 
-from urllib import urlencode
+from purl import URL
 
 
 @click.command()
@@ -64,11 +64,9 @@ def main(scheme, host, port,
     consular.set_debug(debug)
     consular.set_timeout(timeout)
     consular.fallback_timeout = fallback_timeout
-    events_url = "%s://%s:%s/events?%s" % (
-        scheme, host, port,
-        urlencode({
-            'registration': registration_id,
-        }))
+    events_url = str(
+        URL(scheme=scheme, host=host, port=port, path='/events').query_params(
+            {'registration': registration_id}))
     consular.register_marathon_event_callback(events_url)
 
     if sync_interval > 0:

--- a/consular/cli.py
+++ b/consular/cli.py
@@ -12,7 +12,8 @@ from urllib import urlencode
 @click.option('--port', default='7000', type=int,
               help='The port to listen to.')
 @click.option('--consul', default='http://localhost:8500',
-              help='The Consul HTTP API')
+              help='The Consul HTTP API. NOTE: Other agents in the cluster '
+                   'must use the same scheme and port.')
 @click.option('--marathon', default='http://localhost:8080',
               help='The Marathon HTTP API')
 @click.option('--registration-id',

--- a/consular/clients.py
+++ b/consular/clients.py
@@ -206,7 +206,6 @@ class ConsulClient(JsonClient):
             on an agent that cannot be reached.
         """
         super(ConsulClient, self).__init__(endpoint)
-        self.endpoint = endpoint
         self.enable_fallback = enable_fallback
 
     def register_agent_service(self, agent_endpoint, registration):

--- a/consular/clients.py
+++ b/consular/clients.py
@@ -1,4 +1,3 @@
-from urllib import quote
 import json
 
 from twisted.internet import reactor
@@ -242,8 +241,7 @@ class ConsulClient(JsonClient):
         """
         Put a key/value in Consul's k/v store.
         """
-        return self.request(
-            'PUT', '/v1/kv/%s' % (quote(key),), json_data=value)
+        return self.request('PUT', '/v1/kv/%s' % key, json_data=value)
 
     def get_kv_keys(self, keys_path, separator=None):
         """
@@ -259,8 +257,7 @@ class ConsulClient(JsonClient):
         params = {'keys': ''}
         if separator:
             params['separator'] = separator
-        return self.get_json(
-            '/v1/kv/%s' % (quote(keys_path),), params=params)
+        return self.get_json('/v1/kv/%s' % keys_path, params=params)
 
     def delete_kv_keys(self, key, recurse=False):
         """
@@ -272,7 +269,7 @@ class ConsulClient(JsonClient):
             Whether or not to recursively delete all subpaths of the key.
         """
         params = {'recurse': ''} if recurse else {}
-        return self.request('DELETE', '/v1/kv/%s' % (quote(key),), params)
+        return self.request('DELETE', '/v1/kv/%s' % key, params)
 
     def get_catalog_nodes(self):
         """

--- a/consular/main.py
+++ b/consular/main.py
@@ -20,10 +20,6 @@ def get_app_name(app_id):
     return app_id.lstrip('/').replace('/', '-')
 
 
-def get_agent_endpoint(host):
-    return 'http://%s:8500' % (host,)
-
-
 @inlineCallbacks
 def handle_not_found_error(f, *args, **kwargs):
     """
@@ -334,14 +330,13 @@ class Consular(object):
                     'only supports a single port. Only the lowest port (%s) '
                     'will be used.' % (len(ports), app_id, port,))
 
-        agent_endpoint = get_agent_endpoint(host)
         log.msg('Registering %s at %s with %s at %s:%s.' % (
-            app_id, agent_endpoint, task_id, host, port))
+            app_id, host, task_id, host, port))
         registration = self._create_service_registration(app_id, task_id,
                                                          host, port)
 
         return self.consul_client.register_agent_service(
-            agent_endpoint, registration)
+            host, registration)
 
     def deregister_task_service(self, task_id, host):
         """
@@ -352,8 +347,7 @@ class Consular(object):
         :param str host:
             The host address of the machine the task is running on.
         """
-        return self.deregister_consul_service(
-            get_agent_endpoint(host), task_id)
+        return self.deregister_consul_service(host, task_id)
 
     def deregister_consul_service(self, agent_endpoint, service_id):
         """
@@ -590,8 +584,7 @@ class Consular(object):
     def purge_dead_services(self):
         nodes = yield self.consul_client.get_catalog_nodes()
         for node in nodes:
-            self.purge_dead_agent_services(
-                get_agent_endpoint(node['Address']))
+            self.purge_dead_agent_services(node['Address'])
 
     @inlineCallbacks
     def purge_dead_agent_services(self, agent_endpoint):

--- a/consular/tests/test_main.py
+++ b/consular/tests/test_main.py
@@ -1267,7 +1267,7 @@ class ConsularTest(TestCase):
         self.assertEqual(consul_request['method'], 'DELETE')
         self.assertEqual(
             consul_request['url'],
-            'http://localhost:8500/v1/kv/consular/my-app2/?recurse')
+            'http://localhost:8500/v1/kv/consular/my-app2/?recurse=')
         consul_request['deferred'].callback(
             FakeResponse(200, [], json.dumps({})))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Twisted
 Klein
 treq
 click
+purl


### PR DESCRIPTION
Despite the `--consul` option for an endpoint, when apps are synced, Consular assumes that the Consul agent endpoint for Marathon tasks with host "`marathon_host`" is at `http://marathon_host:8500`
